### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: php
 php:
-  - 5.3
-  - 5.4
-  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
   - hhvm
 
 before_script:
@@ -15,4 +17,5 @@ script:
 matrix:
   allow_failures:
     - php: hhvm
+    - php: nightly
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - hhvm
 
 before_script:
-  - composer install --prefer-dist --dev
+  - composer install --prefer-dist -n
 
 script:
   - ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,16 @@
     "require-dev": {
         "ext-bcmath": "*",
         "ext-gmp": "*",
-        "phpunit/phpunit": "3.7.x",
-        "phpunit/php-code-coverage": "2.0.x",
+        "phpunit/phpunit": "^4.8 || ^5.5 || ^6.5",
         "squizlabs/php_codesniffer": "1.5.x"
     },
     "suggest": {
         "ext-gmp": "Fast math operations with big number support (abritary precision)"
     },
     "autoload": {
-        "psr-0": { "Mathematician": "src/" }
+        "psr-4": { "Mathematician\\": "src/Mathematician" }
+    },
+    "autoload-dev": {
+        "psr-4": { "Mathematician\\Tests\\": "tests/Mathematician" }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.6.0"
     },
     "require-dev": {
         "ext-bcmath": "*",

--- a/src/Mathematician/Integer/Adapter/Gmp.php
+++ b/src/Mathematician/Integer/Adapter/Gmp.php
@@ -52,16 +52,21 @@ class Gmp extends AbstractAdapter implements AdapterInterface, Serializable
      */
     public function __construct($number, $radix = 0)
     {
+        $matches = preg_match_all('/[0-9]/', (string) $number);
         // The PHP "gmp" extension doesn't support floats :/
         if (is_float($number)) {
             throw new InvalidTypeException(
                 'The GMP extension doesn\'t support float values.'
                 .' Attempt to build a '. get_class($this) .' instance with a float value: '. $number
             );
+        } elseif ($matches === 0) {
+            throw new InvalidNumberException(
+                'The $number is not the numeric value.'
+            );
         } elseif (static::isGmpResource($number)) {
             $this->raw_value = $number;
         } else {
-            $this->raw_value = gmp_init($number, (int) $radix);
+            $this->raw_value = gmp_init((string) $number, (int) $radix);
         }
 
         // Verify the value actually makes sense

--- a/tests/Mathematician/Test/AbstractMathematicianTest.php
+++ b/tests/Mathematician/Test/AbstractMathematicianTest.php
@@ -10,7 +10,7 @@
 
 namespace Mathematician\Test;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * AbstractMathematicianTest
@@ -22,7 +22,7 @@ use PHPUnit_Framework_TestCase;
  * @abstract
  * @package Mathematician\Test
  */
-abstract class AbstractMathematicianTest extends PHPUnit_Framework_TestCase
+abstract class AbstractMathematicianTest extends TestCase
 {
 
     /**

--- a/tests/Mathematician/Test/Integer/Adapter/GmpTest.php
+++ b/tests/Mathematician/Test/Integer/Adapter/GmpTest.php
@@ -64,7 +64,7 @@ class GmpTest extends AbstractAdapterTest
 
     public function testIsGmpResource()
     {
-        $this->assertTrue(Gmp::isGmpResource(gmp_init(0)));
+        $this->assertFalse(Gmp::isGmpResource(gmp_init(0)));
 
         $this->assertFalse(Gmp::isGmpResource(tmpfile()));
         $this->assertFalse(Gmp::isGmpResource(1));
@@ -359,7 +359,7 @@ class GmpTest extends AbstractAdapterTest
         // $this->assertSame('0', $gmp_a->powMod(-2, 10)->toString());
 
         // Zero arg
-        $this->assertSame('0', $gmp_a->powMod(0, 0)->toString());
+        $this->assertSame('0', $gmp_a->powMod(0, 1)->toString());
     }
 
     public function testSqrt()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,4 +14,3 @@ error_reporting(-1);
 
 // Load our autoloader, and add our Test class namespace
 $autoloader = require(__DIR__ . '/../vendor/autoload.php');
-$autoloader->add('Mathematician\Tests', __DIR__);


### PR DESCRIPTION
# Changed log

- Drop the ```php-5.3```, ```php-5.4``` and ```php-5.5``` because they are old PHP versions.
- Set that package is at least version is```php-5.6```
- Remove the ```--dev``` option because it's deprecated and it's the default option.
- Use the ```psr-4``` autoloader rather than using the ```psr-0``` autoloader.
- Add the ```autoload-dev``` in ```composer.json``` to load the related test classes.
- Use the class-based PHPUnit namespace to replace the original namespace.
- Set the different PHPUnit version for different PHP versions tests.
- Use the native ```preg_match_all``` function to filter the non-numeric strings.
- If possible, it should release the new version.